### PR TITLE
stop sending extra + unnecessary text when opening door

### DIFF
--- a/server.py
+++ b/server.py
@@ -68,10 +68,9 @@ def incoming_text():
     if who not in TARGET_PHONES:
         logging.info("Text was from a rogue number %s. Ignoring.", who)
     elif body in ('y', 'Y', 'yes', 'Yes'):
-        logging.info("Opening door for %s", who)
-        resp.message("Opening door")
+        logging.info('Door opened by %s', who)
+        resp.message('Door opened by %s' % who)
         door_opener.open()
-        send_texts('Door opened by %s' % who)
     return str(resp)
 
 @app.route("/ring", methods=['GET'])

--- a/server.py
+++ b/server.py
@@ -69,7 +69,7 @@ def incoming_text():
         logging.info("Text was from a rogue number %s. Ignoring.", who)
     elif body in ('y', 'Y', 'yes', 'Yes'):
         logging.info('Door opened by %s', who)
-        resp.message('Door opened by %s' % who)
+        send_texts('Door opened by %s' % who)
         door_opener.open()
     return str(resp)
 

--- a/test_server.py
+++ b/test_server.py
@@ -30,7 +30,6 @@ def test_longpoll(client, twilio_client, target_phones):
     assert client.get('/longpoll_open?timeout=1').data == 'punt'
     r = client.post('/incoming_text', data=dict(From=target_phones[1], Body='y'))
     assert r.status_code == 200
-    assert "Opening door" in r.data
     assert client.get('/longpoll_open?timeout=1').data == 'open'
     assert twilio_client.messages.create.call_count == len(target_phones)
     msg = 'Door opened by %s' % target_phones[1]


### PR DESCRIPTION
Currently, the doorbell send 2 confirmation messages whenever one of us confirms it is ok to open the door. Let's pinch a couple of pennies by dropping the first, less information message. 