### PR TITLE
Enable the ability to lock the door when the doorbell is pressed

### DIFF
--- a/server.py
+++ b/server.py
@@ -22,7 +22,7 @@ TWILIO_PHONE = os.getenv('TWILIO_PHONE')
 
 app = Flask(__name__)
 
-class DoorOpener(object):
+class DoorManager(object):
     def __init__(self):
         self.open_door_ts = 0.0
         self.open_cond = threading.Condition()
@@ -45,7 +45,7 @@ class DoorOpener(object):
 
             return 'open' if self._should_open() else 'punt'
 
-door_opener = DoorOpener()
+door_manager = DoorManager()
 
 def send_texts(text_message):
     for to in TARGET_PHONES:
@@ -70,7 +70,7 @@ def incoming_text():
     elif body in ('y', 'Y', 'yes', 'Yes'):
         logging.info('Door opened by %s', who)
         send_texts('Door opened by %s' % who)
-        door_opener.open()
+        door_manager.open()
     return str(resp)
 
 @app.route("/ring", methods=['GET'])
@@ -82,7 +82,7 @@ def ring():
 @app.route("/longpoll_open", methods=['GET'])
 def longpoll_open():
     timeout = float(request.args.get('timeout', 60.0))
-    return door_opener.wait_until_open(timeout=timeout)
+    return door_manager.wait_until_open(timeout=timeout)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/test_server.py
+++ b/test_server.py
@@ -26,11 +26,19 @@ def test_ring(client, twilio_client, target_phones):
     msg = 'Someone rang the doorbell. Respond with "y" to open door'
     assert twilio_client.messages.create.call_args[1]['body'] == msg
 
-def test_longpoll(client, twilio_client, target_phones):
+def test_longpoll_y(client, twilio_client, target_phones):
     assert client.get('/longpoll_open?timeout=1').data == 'punt'
     r = client.post('/incoming_text', data=dict(From=target_phones[1], Body='y'))
     assert r.status_code == 200
     assert client.get('/longpoll_open?timeout=1').data == 'open'
     assert twilio_client.messages.create.call_count == len(target_phones)
     msg = 'Door opened by %s' % target_phones[1]
+    assert twilio_client.messages.create.call_args[1]['body'] == msg
+
+def test_longpoll_n(client, twilio_client, target_phones):
+    r = client.post('/incoming_text', data=dict(From=target_phones[1], Body='n'))
+    assert r.status_code == 200
+    assert client.get('/longpoll_open?timeout=1').data == 'punt'
+    assert twilio_client.messages.create.call_count == len(target_phones)
+    msg = 'Door locked by %s' % target_phones[1]
     assert twilio_client.messages.create.call_args[1]['body'] == msg


### PR DESCRIPTION
Enable the ability to lock the door when the doorbell is pressed.

Notes:
- Rename `DoorOpener` to `DoorManager`, since it will now do things other than `open` the door
- `DoorManager` is initialized in the locked state
- if locked in response to someone pressing the doorbell, the `DoorManager` will remain locked until the next time the doorbell is pressed
- new tests 🥇 